### PR TITLE
note to self

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -19,4 +19,4 @@ jobs:
         with:
           git-user-email: wise.spot4836@fastmail.com'
           git-user-name: dependency-mgmt
-          pre-commit-script: npm run test
+          pre-commit-script: npm run test # new PR won't trigger tests


### PR DESCRIPTION
via https://github.com/neverendingqs/gh-action-node-update-deps#faq
> Why doesn't the resulting pull request not trigger any GitHub Action workflows?
>
> That is [by design when using the repository's GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow). You can circumvent this by creating a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) or a [installation access token](https://docs.github.com/en/developers/apps/building-github-apps/authenticating-with-github-apps#authenticating-as-an-installation). Note that doing so exposes you to vulnerabilities described on [Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/).